### PR TITLE
Mixins service

### DIFF
--- a/Cloudy-Canvas.Tests/Cloudy-Canvas.Tests.csproj
+++ b/Cloudy-Canvas.Tests/Cloudy-Canvas.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <RootNamespace>Cloudy_Canvas.Tests</RootNamespace>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Cloudy-Canvas\Cloudy-Canvas.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Cloudy-Canvas.Tests/Service/MixinsServiceTests.cs
+++ b/Cloudy-Canvas.Tests/Service/MixinsServiceTests.cs
@@ -6,20 +6,28 @@ namespace Cloudy_Canvas.Tests
 {
     public class MixinsServiceTests
     {
-        [Fact]
-        public void DailyLyra()
+        [Theory]
+        [InlineData("created_at:{{today}}, Lyra", "created_at:2021-04-23, Lyra")]
+        [InlineData("created_at:{{current_year}}, Lyra", "created_at:2021, Lyra")]
+        [InlineData("created_at:{{current_year}}-{{current_month}}, Lyra", "created_at:2021-04, Lyra")]
+        [InlineData("created_at:{{current_year}}-{{current_month}}-{{current_day}}, Lyra", "created_at:2021-04-23, Lyra")]
+        [InlineData("created_at:{{current_year}}-{{current_month}}-{{current_day}}T{{current_hour}}, Lyra", "created_at:2021-04-23T17, Lyra")]
+        [InlineData("created_at:{{current_year}}-{{current_month}}-{{current_day}}T{{current_hour}}:{{current_minute}}, Lyra", "created_at:2021-04-23T17:20, Lyra")]
+        [InlineData("created_at:{{current_year}}-{{current_month}}-{{current_day}}T{{current_hour}}:{{current_minute}}:{{current_second}}, Lyra", "created_at:2021-04-23T17:20:07, Lyra")]
+        [InlineData("{{today}}{{today}}", "2021-04-232021-04-23")]//Replaces all 
+        public void TranspileThoery(string query, string expected)
         {
             var helper = new MixinsService(new MockDateTimeService());
-            var result = helper.Transpile("created_at:{{today}}, Lyra");
-            Assert.Equal("created_at:2021-04-23, Lyra",result);
+            var result = helper.Transpile(query);
+            Assert.Equal(expected, result);
         }
     }
 
     public class MockDateTimeService : IDateTimeService
     {
-        public DateTime Now()
+        public DateTime UtcNow()
         {
-            return new DateTime(2021, 4, 23);
+            return new DateTime(2021, 4, 23, 17, 20, 7);
         }
     }
 }

--- a/Cloudy-Canvas.Tests/Service/MixinsServiceTests.cs
+++ b/Cloudy-Canvas.Tests/Service/MixinsServiceTests.cs
@@ -1,0 +1,25 @@
+using System;
+using Xunit;
+using Cloudy_Canvas.Service;
+
+namespace Cloudy_Canvas.Tests
+{
+    public class MixinsServiceTests
+    {
+        [Fact]
+        public void DailyLyra()
+        {
+            var helper = new MixinsService(new MockDateTimeService());
+            var result = helper.Transpile("created_at:{{today}}, Lyra");
+            Assert.Equal("created_at:2021-04-23, Lyra",result);
+        }
+    }
+
+    public class MockDateTimeService : IDateTimeService
+    {
+        public DateTime Now()
+        {
+            return new DateTime(2021, 4, 23);
+        }
+    }
+}

--- a/Cloudy-Canvas.sln
+++ b/Cloudy-Canvas.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.30907.101
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cloudy-Canvas", "Cloudy-Canvas\Cloudy-Canvas.csproj", "{94B58A3C-AD2E-4062-AEA4-6209F2E11BB8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cloudy-Canvas.Tests", "Cloudy-Canvas.Tests\Cloudy-Canvas.Tests.csproj", "{ED8DDDFE-16D9-437E-881A-C880153409FB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{94B58A3C-AD2E-4062-AEA4-6209F2E11BB8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{94B58A3C-AD2E-4062-AEA4-6209F2E11BB8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{94B58A3C-AD2E-4062-AEA4-6209F2E11BB8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ED8DDDFE-16D9-437E-881A-C880153409FB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ED8DDDFE-16D9-437E-881A-C880153409FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ED8DDDFE-16D9-437E-881A-C880153409FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ED8DDDFE-16D9-437E-881A-C880153409FB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Cloudy-Canvas/Modules/BooruModule.cs
+++ b/Cloudy-Canvas/Modules/BooruModule.cs
@@ -14,11 +14,13 @@
     {
         private readonly BooruService _booru;
         private readonly LoggingService _logger;
+        private readonly MixinsService _mixins;
 
-        public BooruModule(BooruService booru, LoggingService logger)
+        public BooruModule(BooruService booru, LoggingService logger, MixinsService mixins)
         {
             _booru = booru;
             _logger = logger;
+            _mixins = mixins;
         }
 
         [Command("pick")]
@@ -30,6 +32,8 @@
             {
                 return;
             }
+
+            query = _mixins.Transpile(query);
 
             if (!await CheckBadlistsAsync(query, settings))
             {
@@ -86,6 +90,8 @@
             {
                 return;
             }
+
+            query = _mixins.Transpile(query);
 
             if (!await CheckBadlistsAsync(query, settings))
             {

--- a/Cloudy-Canvas/Program.cs
+++ b/Cloudy-Canvas/Program.cs
@@ -43,6 +43,8 @@ namespace Cloudy_Canvas
                 var config = hostContext.Configuration;
                 services.Configure<DiscordSettings>(config.GetSection(nameof(DiscordSettings)));
                 services.Configure<ManebooruSettings>(config.GetSection(nameof(ManebooruSettings)));
+                services.AddTransient<IDateTimeService,DateTimeService>();
+                services.AddTransient<MixinsService>();
                 services.AddTransient<BooruService>();
                 services.AddSingleton<LoggingService>();
                 var settings = FileHelper.LoadAllPresettingsAsync().GetAwaiter().GetResult();

--- a/Cloudy-Canvas/Service/DateTimeService.cs
+++ b/Cloudy-Canvas/Service/DateTimeService.cs
@@ -1,13 +1,13 @@
 using System;
 public interface IDateTimeService
 {
-    DateTime Now();
+    DateTime UtcNow();
 }
 
 public class DateTimeService : IDateTimeService
 {
-    public DateTime Now()
+    public DateTime UtcNow()
     {
-        return DateTime.Now;
+        return DateTime.UtcNow;
     }
 }

--- a/Cloudy-Canvas/Service/DateTimeService.cs
+++ b/Cloudy-Canvas/Service/DateTimeService.cs
@@ -1,0 +1,13 @@
+using System;
+public interface IDateTimeService
+{
+    DateTime Now();
+}
+
+public class DateTimeService : IDateTimeService
+{
+    public DateTime Now()
+    {
+        return DateTime.Now;
+    }
+}

--- a/Cloudy-Canvas/Service/MixinsService.cs
+++ b/Cloudy-Canvas/Service/MixinsService.cs
@@ -1,0 +1,18 @@
+﻿namespace Cloudy_Canvas.Service
+{
+    using System;
+
+    public class MixinsService
+    {
+        private readonly IDateTimeService _dateTime;
+        public MixinsService(IDateTimeService dateTime)
+        {
+            _dateTime = dateTime;
+        }
+
+        public string Transpile(string query)
+        {
+            return query.Replace("{{today}}",_dateTime.Now().ToString("yyyy-MM-dd"));
+        }
+    }
+}

--- a/Cloudy-Canvas/Service/MixinsService.cs
+++ b/Cloudy-Canvas/Service/MixinsService.cs
@@ -12,7 +12,14 @@
 
         public string Transpile(string query)
         {
-            return query.Replace("{{today}}",_dateTime.Now().ToString("yyyy-MM-dd"));
+            return query.Replace("{{today}}", _dateTime.UtcNow().ToString("yyyy-MM-dd"))
+                        .Replace("{{current_year}}", _dateTime.UtcNow().ToString("yyyy"))
+                        .Replace("{{current_month}}", _dateTime.UtcNow().ToString("MM"))
+                        .Replace("{{current_day}}", _dateTime.UtcNow().ToString("dd"))
+                        .Replace("{{current_hour}}", _dateTime.UtcNow().ToString("HH"))
+                        .Replace("{{current_minute}}", _dateTime.UtcNow().ToString("mm"))
+                        .Replace("{{current_second}}", _dateTime.UtcNow().ToString("ss"))
+                        ;
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -53,6 +53,23 @@ Important terms:
 
 ---
 
+### Mixins:
+
+Use mixins in the `<query>` to introduce values that are calculated when the query is executed.
+Example: If today was May 23rd, 2021, then `;pick created_at:{{today}}, lyra` would execute as `;pick created_at:2021-05-23, lyra`. All date values are generatd using UTC ("Zulu") time. [More info](https://manebooru.art/pages/search_syntax#date-range).
+
+| Template | Info |
+| -------- | ---- |
+| {{today}} | The current day, month, and year using the ISO 8601 standard. |
+| {{current_year}} | The current year. |
+| {{current_month}} | The current month. |
+| {{current_day}} | The current day. |
+| {{current_hour}} | The current hour. |
+| {{current_minute}} | The current minute. |
+| {{current_second}} | The current second. |
+
+---
+
 ### Admin Module
 *Only users with the specified admin role may use the commands in this module*
 


### PR DESCRIPTION
Introduces a way to calculate values when a query is executed. Useful for building aliases that benefit from values you need at the point of execution. 
Example: `;alias add "daily oc" pick created_at:{{today}}, oc`
When `;daily oc` is executed, it'll substitute today's date (UTC). Like `created_at:2021-05-23, oc`

This PR also introduces a test suite to the project. `dotnet test` now works.

The intention was to write this in such a way others could introduce their own mixins as they think of them.