### PR TITLE
Add github action workflow to publish binary & run tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,75 @@
+name: Test and Publish
+
+on:
+  push:
+      branches:
+        - mane
+  pull_request:
+      branches:
+        - mane
+  release:
+    types:
+      - created
+
+env:
+  DOTNET_VERSION: '5.0.301' # The .NET SDK version to use
+
+jobs:
+  tests:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            Cloudy-Canvas/bin
+            Cloudy-Canvas/obj
+            Cloudy-Canvas.Tests/bin
+            Cloudy-Canvas.Tests/obj
+          key: dotnet-dep-builds
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+      - name: Test
+        run: dotnet test --no-restore --verbosity normal
+  publish:
+    name: Publish Binary
+    runs-on: ubuntu-latest
+    needs: [tests]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            Cloudy-Canvas/bin
+            Cloudy-Canvas/obj
+            Cloudy-Canvas.Tests/bin
+            Cloudy-Canvas.Tests/obj
+          key: dotnet-dep-builds
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Publish
+        run: dotnet publish --self-contained -r linux-x64 -c Release -p:PublishReadyToRun=true
+      - name: Upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: Cloudy-Canvas.linux-x64
+          path: |
+            Cloudy-Canvas/bin/Release/net5.0/linux-x64/publish/Cloudy-Canvas
+            Cloudy-Canvas/bin/Release/net5.0/linux-x64/publish/Cloudy-Canvas.pdb
+            Cloudy-Canvas/bin/Release/net5.0/linux-x64/publish/appsettings*.json
+          retention-days: 30

--- a/Cloudy-Canvas/Cloudy-Canvas.csproj
+++ b/Cloudy-Canvas/Cloudy-Canvas.csproj
@@ -4,6 +4,10 @@
     <TargetFramework>net5.0</TargetFramework>
     <UserSecretsId>dotnet-Cloudy_Canvas-C054BD3A-F4E3-4221-81C0-9AE116BDD30F</UserSecretsId>
     <RootNamespace>Cloudy_Canvas</RootNamespace>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The action workflow automatically tests and build Cloudy. Once done, it makes a publication and uploads it as zip file to the job, which should just run on up-to-date Linux systems (Ubuntu).